### PR TITLE
fixed memory leak on dispose

### DIFF
--- a/lib/jpegtran_ffi.dart
+++ b/lib/jpegtran_ffi.dart
@@ -280,7 +280,15 @@ class JpegTransformer {
   void dispose() {
     calloc.free(_jpegBuf);
 
-    int res = _bindings.tjDestroy(_handleTransform);
+    int res = _bindings.tjDestroy(_handleCompress);
+    if (res != 0) {
+      throw Exception("tjDestroy failed");
+    }
+    res = _bindings.tjDestroy(_handleDecompress);
+    if (res != 0) {
+      throw Exception("tjDestroy failed");
+    }
+    res = _bindings.tjDestroy(_handleTransform);
     if (res != 0) {
       throw Exception("tjDestroy failed");
     }


### PR DESCRIPTION
changes:
- fixed memory leak on dispose() call
- bumped libjpeg-turbo version to 3.0.3